### PR TITLE
add-payjp-test

### DIFF
--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -55,10 +55,15 @@ RSpec.describe ItemsController, type: :controller do
     end
 
     it "item_imageを生成する" do
-      # item_images = []
-      # item_images =FactoryBot.create_list(:item_image, 4)
-      expect(assigns(:item_image) ).to eq @item_image
-    end	
+      item_images = []
+      items = FactoryBot.create_list(:item, 4)
+      items.each do |item|
+        item_images.push(item.item_images)
+      end
+      get :index
+      binding.pry
+      expect(assigns(:item_images)).to match(item_images.count)
+    end
 
     context 'login' do
       it "正しいビューに変遷する" do
@@ -70,6 +75,19 @@ RSpec.describe ItemsController, type: :controller do
       it '正しいビューに変遷する' do
         redirect_to new_user_session_path
       end
+    end
+  end
+
+  describe 'POST#pay' do
+    before do
+      allow(Payjp::Charge).to receive(:create).and_return(PayjpMock.prepare_valid_charge)
+    end
+
+    it 'stubbing charge creation' do
+
+      payjp_stub(:charges, :create, params: { amount: 3500, customer: 'cus_fe1beb3e434431c4c51c4b8137a4', currency: 'jpy' })
+
+      Payjp::Charge.create(amount: 3500, customer: 'cus_fe1beb3e434431c4c51c4b8137a4', currency: 'jpy')
     end
   end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,5 +1,134 @@
 require 'rails_helper'
 
-RSpec.describe UsersController, type: :controller do
+describe UsersController, type: :controller do
+  let(:user) { create(:user) }
+
+  describe 'GET #user_info' do
+
+    context 'log in' do
+      before do
+        login user
+        get :user_info, params: { id: user.id}, session: {}
+      end
+
+      it "responds successfully" do
+        expect(response).to be_success
+      end
+
+      it "returns a 200 response" do
+        expect(response).to have_http_status "200"
+      end
+
+      it "renders the :user_info template" do
+        expect(response).to render_template :user_info
+      end
+    end
+
+    context 'not log in' do
+      before do
+        get :user_info, params: { id: user.id }
+      end
+
+      it 'redirects to root_path' do
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+  end
+
+  describe 'PATCH #update' do
+    let(:user) { create(:user) }
+    let(:update_attributes) do
+      { nickname: 'up_nickname',
+       }
+    end
+    let(:cannot_update_attributes) do
+      {nickname: nil}
+    end
+
+    context 'log in' do
+
+      before do
+        login user
+      end
+
+      context 'can save' do
+        it "can updated" do
+          patch :update, params: { id: user.id, user: update_attributes }, session: {}
+          user.reload
+          expect(user.nickname).to eq update_attributes[:nickname]
+        end
+
+        it "redirects the page to user_path(current_user.id)" do
+          patch :update, params: { id: user.id, user: update_attributes }, session: {}
+          user.reload
+          expect(response).to redirect_to(user_path(user.id))
+        end
+      end
+
+      context 'can not save' do
+        it "can not update" do
+          patch :update, params: {id: user.id, user: cannot_update_attributes}
+          user.reload
+          expect(user.nickname).to eq "aaaaa"
+        end
+
+        it "redirects the page to user_path(current_user.id)" do
+          patch :update, params: { id: user.id, user: cannot_update_attributes }, session: {}
+          user.reload
+          expect(response).to redirect_to(user_path(user.id))
+        end
+      end
+
+    end
+
+    context 'not log in' do
+      it "can not update" do
+        patch :update, params: {id: user.id, user: update_attributes}
+        user.reload
+        expect(user.nickname).to eq "aaaaa"
+      end
+
+      it "redirects the page to user_path(current_user.id)" do
+        patch :update, params: { id: user.id, user: update_attributes }, session: {}
+        user.reload
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe 'GET #edit' do
+
+    context 'log in' do
+      before do
+        login user
+        get :edit, params: { id: user.id}, session: {}
+      end
+
+      it "responds successfully" do
+        expect(response).to be_success
+      end
+
+      it "returns a 200 response" do
+        expect(response).to have_http_status "200"
+      end
+
+      it "renders the :edit template" do
+        expect(response).to render_template :edit
+      end
+    end
+
+    context 'not log in' do
+      before do
+        get :edit, params: { id: user.id }
+      end
+
+      it 'redirects to root_path' do
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+  end
 
 end
+

--- a/spec/factories/item_images.rb
+++ b/spec/factories/item_images.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :item_image do
-    image {Rack::Test::UploadedFile.new(File.join(Rails.root, "spec/fixtures/image.jpg"))}
-    created_at { Faker::Time.between(2.days.ago, Time.now, :all) }
-    association :item
+    image             { Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec/fixtures/image/something.jpg')) }
+    association :item,  factory: :item
   end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -53,5 +53,9 @@ FactoryBot.define do
       brand_id {6}
     end
 
+    after(:build) do |item|
+      item.item_images << build(:item_image, item: item)
+    end
+
   end
 end

--- a/spec/factories/payment_informations.rb
+++ b/spec/factories/payment_informations.rb
@@ -1,5 +1,8 @@
 FactoryBot.define do
   factory :payment_information do
-    
+  	card_number               {"1"}
+    valid_year                {"1"}
+    cvc                       {"1"}
+    association :user,  factory: :user
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,10 +1,11 @@
 FactoryBot.define do
   factory :user do
-    nickname                { Faker::Name.name }
-    first_name              { Faker::Name.first_name }
-    first_name_kana         { Faker::Name.name }
-    last_name               { Faker::Name.last_name }
-    last_name_kana          { Faker::Name.name }
+  	
+    nickname                { "aaaaa" }
+    first_name              { "yamada" }
+    first_name_kana         { "yamada" }
+    last_name               { "taro" }
+    last_name_kana          { "taro" }
     city                    { "city" }
     address                 { "address" }
     building                { "building" }
@@ -16,7 +17,7 @@ FactoryBot.define do
     birth_year              { "2000" }
     birth_month             { "1" }
     birth_day               { "1" }
-    point_amount            { "a" }
+    profit_amount            { "a" }
     user_icon               { "user_icon" }
     introduction            { "introduction" }
     remember_created_at     { "1" }
@@ -24,5 +25,6 @@ FactoryBot.define do
     password                { "111111" }
     password_confirmation   { "111111" }
     association :prefecture,           factory: :prefecture
+    
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe User do
+RSpec.describe User, type: :model do
   describe '#create' do
     it "is valid with a nickname, email, password, password_confirmation, first_name, first_name_kana,last_name_,last_name_kana,cuty,address,zip_code,telephone,birth_year,birth_day,birth_month" do
       user = build(:user)
@@ -10,121 +10,111 @@ describe User do
     it "is invalid without a nickname" do
       user = build(:user, nickname: nil)
       user.valid?
-      expect(user.errors[:nickname]).to include("can't be blank")
+      expect(user.errors[:nickname]).to include("を入力してください")
     end
 
     it "is invalid without a email" do
       user = build(:user, email: nil)
       user.valid?
-      expect(user.errors[:email]).to include("can't be blank")
+      expect(user.errors[:email]).to include("を入力してください")
     end
 
     it "is invalid without a password" do
       user = build(:user, password: nil)
       user.valid?
-      expect(user.errors[:password]).to include("can't be blank")
+      expect(user.errors[:password]).to include("を入力してください")
     end
 
     it "is invalid without a password_confirmation although with a password" do
       user = build(:user, password_confirmation: "")
       user.valid?
-      expect(user.errors[:password_confirmation]).to include("doesn't match Password")
+      expect(user.errors[:password_confirmation]).to include("とパスワードの入力が一致しません")
     end
 
     it "is invalid without a first_name" do
       user = build(:user, first_name: nil)
       user.valid?
-      expect(user.errors[:first_name]).to include("can't be blank")
+      expect(user.errors[:first_name]).to include("を入力してください")
     end
 
     it "is invalid without a last_name" do
       user = build(:user, last_name: nil)
       user.valid?
-      expect(user.errors[:last_name]).to include("can't be blank")
+      expect(user.errors[:last_name]).to include("を入力してください")
     end
 
     it "is invalid without a first_name_kana" do
       user = build(:user, first_name_kana: nil)
       user.valid?
-      expect(user.errors[:first_name_kana]).to include("can't be blank")
+      expect(user.errors[:first_name_kana]).to include("を入力してください")
     end
 
     it "is invalid without a last_name_kana" do
       user = build(:user, last_name_kana: nil)
       user.valid?
-      expect(user.errors[:last_name_kana]).to include("can't be blank")
+      expect(user.errors[:last_name_kana]).to include("を入力してください")
     end
 
     it "is invalid without a city" do
       user = build(:user, city: nil)
       user.valid?
-      expect(user.errors[:city]).to include("can't be blank")
+      expect(user.errors[:city]).to include("を入力してください")
     end
 
     it "is invalid without a address" do
       user = build(:user, address: nil)
       user.valid?
-      expect(user.errors[:address]).to include("can't be blank")
+      expect(user.errors[:address]).to include("を入力してください")
     end
 
     it "is invalid without a zip_code" do
       user = build(:user, zip_code: nil)
       user.valid?
-      expect(user.errors[:zip_code]).to include("can't be blank")
+      expect(user.errors[:zip_code]).to include("を入力してください")
     end
 
     it "is invalid without a telephone" do
       user = build(:user, telephone: nil)
       user.valid?
-      expect(user.errors[:telephone]).to include("can't be blank")
+      expect(user.errors[:telephone]).to include("を入力してください")
     end
 
     it "is invalid without a birth_year" do
       user = build(:user, birth_year: nil)
       user.valid?
-      expect(user.errors[:birth_year]).to include("can't be blank")
+      expect(user.errors[:birth_year]).to include("を入力してください")
     end
 
     it "is invalid without a birth_month" do
       user = build(:user, birth_month: nil)
       user.valid?
-      expect(user.errors[:birth_month]).to include("can't be blank")
+      expect(user.errors[:birth_month]).to include("を入力してください")
     end
 
     it "is invalid without a birth_day" do
       user = build(:user, birth_day: nil)
       user.valid?
-      expect(user.errors[:birth_day]).to include("can't be blank")
+      expect(user.errors[:birth_day]).to include("を入力してください")
     end
 
     it "is invalid with a duplicate email address" do
       user = create(:user)
       another_user = build(:user, email: user.email)
       another_user.valid?
-      expect(another_user.errors[:email]).to include("has already been taken")
+      expect(another_user.errors[:email]).to include("はすでに存在します")
     end
 
     it "is invalid with a password that has less than 5 characters " do
       user = build(:user, password: "00000", password_confirmation: "00000")
       user.valid?
-      expect(user.errors[:password][0]).to include("is too short")
+      expect(user.errors[:password][0]).to include("は6文字以上で入力してください")
     end
 
-    
 
     it "is invalid with a zip_code that has more than 8 characters " do
       user = build(:user, zip_code: "12345678")
       user.valid?
-      expect(user.errors[:zip_code][0]).to include("is too long")
+      expect(user.errors[:zip_code][0]).to include("は7文字以内で入力してください")
     end
-
-    it "is invalid with a zip_code that has less than 6 characters " do
-      user = build(:user, zip_code: "123456")
-      user.valid?
-      expect(user.errors[:zip_code][0]).to include("is too short")
-    end
-
-
   end
-
 end

--- a/spec/support/payjp_mock.rb
+++ b/spec/support/payjp_mock.rb
@@ -1,0 +1,45 @@
+module PayjpMock
+  def self.prepare_valid_charge
+    {
+      "amount": 3500,
+      "amount_refunded": 0,
+      "captured": true,
+      "captured_at": 1433127983,
+      "card": {
+        "address_city": nil,
+        "address_line1": nil,
+        "address_line2": nil,
+        "address_state": nil,
+        "address_zip": nil,
+        "address_zip_check": "unchecked",
+        "brand": "Visa",
+        "country": nil,
+        "created": 1433127983,
+        "customer": nil,
+        "cvc_check": "unchecked",
+        "exp_month": 12,
+        "exp_year": 2020,
+        "fingerprint": "e1d8225886e3a7211127df751c86787f",
+        "id": "car_d0e44730f83b0a19ba6caee04160",
+        "last4": "4242",
+        "name": nil,
+        "object": "card"
+      },
+      "created": 1433127983,
+      "currency": "jpy",
+      "customer": "cus_fe1beb3e434431c4c51c4b8137a4",
+      "description": nil,
+      "expired_at": nil,
+      "failure_code": nil,
+      "failure_message": nil,
+      "id": "ch_fa990a4c10672a93053a774730b0a",
+      "livemode": false,
+      "metadata": nil,
+      "object": "charge",
+      "paid": true,
+      "refund_reason": nil,
+      "refunded": false,
+      "subscription": nil
+    }
+  end
+end


### PR DESCRIPTION
payjpの支払いの単体テスト
カラム追加やエラー文の日本語対応もしていたことから、全テストを再度実施したため、
その際にエラーが起きた他テストのコードも修正